### PR TITLE
更新README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ _book
 *.log
 node_modules
 .DS_Store
+
+# Vim swaps
+.*.sw[a-p]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,18 @@ TODO:
 
 1. 下载以下软件
     * [Homebrew](http://brew.sh/) 在命令行里运行：`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-    * [node](http://nodejs.org/) 在命令行里运行：`brew install nodejs`
+    * 使用清华大学提供的Homebrew镜像:
+    ```bash
+    cd /usr/local
+    git remote set-url origin https://mirrors.tuna.tsinghua.edu.cn/git/brew.git
+
+    cd /usr/local/Library/Taps/homebrew/homebrew-core
+    git remote set-url origin https://mirrors.tuna.tsinghua.edu.cn/git/homebrew-core.git
+
+    brew update
+    ```
+
+    * [node](http://nodejs.org/) 在命令行里运行：`brew install node`
     * [gitbook](https://www.gitbook.com/) 在命令行里运行：`sudo npm install gitbook-cli -g`  管理员权限要的是当前mac用户的密码
     * 推荐下载git可视化[sourcetree](https://www.sourcetreeapp.com/)
     * 推荐下载编辑器[atom](http://atom.io/)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ TODO:
 
 另外可以看这个说明：http://www.jianshu.com/p/1e402922ee32/
 
+社区公认的Markdown语法标准是CommonMark，官网为[http://commonmark.org/](http://commonmark.org/)。CommonMark官网提供了Markdown的[参考](http://commonmark.org/help/)、[细节标准](http://spec.commonmark.org/)、[教程](http://commonmark.org/help/tutorial/)和一个用于尝试Markdown的[Playground](http://spec.commonmark.org/dingus/)。
+
 ## Gitbook特有的语法
 
 * 页面中插入一个目录导览：`<!- - toc -->` （注意：去掉横线之间的空格）


### PR DESCRIPTION
距离README.md上次更新之后，brew中nodejs包重命名为node，所以更新了Homebrew中Nodejs的安装方法，并且由于github.com连接速度的原因，在README中加入了使用Tuna提供的Homebrew镜像的方法。

除此之外，加入了CommonMark标准的链接。
